### PR TITLE
build: set GNU17 for lemon compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ ENDIF()
 ADD_CUSTOM_COMMAND(
   OUTPUT contrib/lemon
   DEPENDS contrib/lemon.c contrib/lempar.c
-  COMMAND gcc -o contrib/lemon contrib/lemon.c
+  COMMAND gcc -std=gnu17 -o contrib/lemon contrib/lemon.c
   COMMENT "Generating lemon parser generator"
 )
 


### PR DESCRIPTION
GCC15 has changed the default from GNU17 (Since GCC8) to GNU23 and this is breaking lemon compilation.

So, simply set -std=gnu17 for lemon.c so it compiles again.