### PR TITLE
main: fix stdin parsing after option deferral

### DIFF
--- a/main.c
+++ b/main.c
@@ -465,12 +465,13 @@ int main(int argc, char **argv)
 {
 	bool array_mode = false;
 	int opt, rv = 0, limit = 0x7FFFFFFF;
-	int te_opt = -1;
 	bool t_e_flag = false;
 	FILE *input = stdin;
 	struct json_object *jsobj = NULL;
 	const char *jserr = NULL, *source = NULL, *separator = " ";
-	char *te_source = NULL;
+	int te_opts[argc];
+	char *te_sources[argc];
+	int te_count = 0;
 
 	if (argc == 1)
 	{
@@ -523,8 +524,9 @@ int main(int argc, char **argv)
 			t_e_flag = true;
 
 			// defer parsing and filtering
-			te_source = optarg;
-			te_opt = opt;
+			te_sources[te_count] = optarg;
+			te_opts[te_count] = opt;
+			te_count++;
 			break;
 
 		case 'q':
@@ -551,8 +553,8 @@ int main(int argc, char **argv)
 	}
 
 	// Handle filtering and other JSON operations
-	if(te_opt != -1 && t_e_flag)
-		if (!filter_json(te_opt, jsobj, te_source, separator, limit))
+	for (int i = 0; i < te_count; i++)
+		if (!filter_json(te_opts[i], jsobj, te_sources[i], separator, limit))
 			rv = 1;
 
 out:

--- a/main.c
+++ b/main.c
@@ -466,7 +466,7 @@ int main(int argc, char **argv)
 	bool array_mode = false;
 	int opt, rv = 0, limit = 0x7FFFFFFF;
 	int te_opt = -1;
-	bool i_s_flag = false, t_e_flag = false;
+	bool t_e_flag = false;
 	FILE *input = stdin;
 	struct json_object *jsobj = NULL;
 	const char *jserr = NULL, *source = NULL, *separator = " ";
@@ -492,8 +492,6 @@ int main(int argc, char **argv)
 			goto out;
 
 		case 'i':
-			i_s_flag = true;
-
 			input = fopen(optarg, "r");
 
 			if (!input)
@@ -508,8 +506,6 @@ int main(int argc, char **argv)
 			break;
 
 		case 's':
-			i_s_flag = true;
-
 			source = optarg;
 			break;
 
@@ -543,7 +539,7 @@ int main(int argc, char **argv)
 	}
 
 	// Deferred JSON parsing after option parsing is complete
-	if (!jsobj && i_s_flag)
+	if (!jsobj && t_e_flag)
 	{
 		jsobj = parse_json(input, source, &jserr, array_mode);
 		if (!jsobj)


### PR DESCRIPTION
 * main: fix stdin parsing after option deferral
    
    Commit e5a07f4 deferred JSON parsing until after all options are
    processed, but gated the parse on i_s_flag which is only set by -i
    and -s. When reading from stdin (no -i or -s), i_s_flag was never
    set, so jsobj stayed NULL and all -e/-t filters returned exit code 1.
    
    Replace i_s_flag with t_e_flag: parse whenever a filter expression
    was given, regardless of the input source.
    
    Fixes: https://github.com/openwrt/openwrt/issues/22439
    Fixes: e5a07f468508 ("main: defer processing until options are processed")

 * main: fix multiple -e/-t expressions after option deferral
    
    Commit e5a07f4 introduced deferred filtering but stored only a single
    (te_opt, te_source) pair, so each -e/-t option overwrote the previous
    one and only the last expression was ever evaluated.
    
    Replace the single pair with VLA arrays sized to argc (an upper bound
    on the number of expressions) and process all collected expressions
    after parsing.
    
    Fixes: e5a07f468508 ("main: defer processing until options are processed")